### PR TITLE
Filter selectors for Zenefits

### DIFF
--- a/src/css/pendota_base.css
+++ b/src/css/pendota_base.css
@@ -1,8 +1,3 @@
-/* Reset to avoid parent styles leaking in */
-.v1-zenefits ._pendota-wrapper_ * {
-    all: initial;
-}
-
 ._pendota-outline_,
 ._pendota-outline_:hover,
 ._pendota-outline_:visited,

--- a/src/css/pendota_base.css
+++ b/src/css/pendota_base.css
@@ -1,3 +1,8 @@
+/* Reset to avoid parent styles leaking in */
+.v1-zenefits ._pendota-wrapper_ * {
+    all: initial;
+}
+
 ._pendota-outline_,
 ._pendota-outline_:hover,
 ._pendota-outline_:visited,

--- a/src/scripts/insertUIDefinitions.js
+++ b/src/scripts/insertUIDefinitions.js
@@ -47,6 +47,7 @@ if (!pendota._pendotaUIIsInjected) {
 	pendota.uiTextBlockId = "_pendota-text-block_";
 	pendota.uiTextTableId = "_pendota_text-table_";
 	pendota.uiAttrSelectorId = "_pendota-attr-selector_";
+	pendota.uiAttrTableId = "_pendota_attr-table_";
 	pendota.uiItemInputClass = "_pendota_form-control_";
 	pendota.copy_icon_url = chrome.extension.getURL(
 		"/src/ui/images/copy_icon.ico"
@@ -1072,10 +1073,19 @@ if (!pendota._pendotaUIIsInjected) {
 		}
 		
 		// Add id
-		document.getElementById(pendota.uiIdTableId).appendChild(createItemRow("id", _id_, '#' + _id_));
+		if (_id_ === "") {
+			document.getElementById(pendota.uiIdTableId).classList.add("_pendota-hidden_");
+		} else {
+			document.getElementById(pendota.uiIdTableId).classList.remove("_pendota-hidden_");
+			document.getElementById(pendota.uiIdTableId).appendChild(createItemRow("id", _id_, '#' + _id_));
+		}
 
 		// If no classes, show a blank
-		if (_classNames_.length === 0) document.getElementById(pendota.uiClassTableId).appendChild(createItemRow("class", '', '.' ));
+		if (_classNames_.length === 0) {
+			document.getElementById(pendota.uiClassTableId).classList.add("_pendota-hidden_");
+		} else {
+			document.getElementById(pendota.uiClassTableId).classList.remove("_pendota-hidden_");
+		}
 		// Build class rows
 		for (var i = 0; i < _classNames_.length; i++) {
 			document.getElementById(pendota.uiClassTableId).appendChild(createItemRow("class", _classNames_[i], '.' + _classNames_[i]));
@@ -1086,14 +1096,12 @@ if (!pendota._pendotaUIIsInjected) {
 			document.getElementById(pendota.uiAttrBlockId).classList.add("_pendota-hidden_");
 		} else {
 			document.getElementById(pendota.uiAttrBlockId).classList.remove("_pendota-hidden_");
-			var attrsOnly = _attrs_.map(function(v) {return v.attribute});
-			document.getElementById(pendota.uiAttrSelectorId).innerHTML = "";
-			var attrSel = createSelector(attrsOnly);
-			attrSel.addEventListener("change", function() {
-				updateCustomAttrsList(_attrs_);
-			});
-			document.getElementById(pendota.uiAttrSelectorId).appendChild(attrSel);
-			updateCustomAttrsList(_attrs_);
+			// Build attribute rows
+			for (var i = 0; i < _attrs_.length; i++) {
+				document.getElementById(pendota.uiAttrTableId).appendChild(createItemRow(_attrs_[i].attribute, _attrs_[i].value, "[" +_attrs_[i].attribute + "]='" + _attrs_[i].value + "'"));
+			}
+
+		
 		}
 
 		// Define the copy and add functions for all icons

--- a/src/scripts/insertUIDefinitions.js
+++ b/src/scripts/insertUIDefinitions.js
@@ -957,10 +957,13 @@ if (!pendota._pendotaUIIsInjected) {
 	pendota.updatePendotaContents = function (e) {
 		// Get the target element's Id and Classes
 		var _id_ = (!!e ? e.id : "") || "";
-		var _classNames_ = (!!e ? e.classes : []) || [];
-		var _attrs_ = (!!e ? e.attributes : []) || [];
+		_id_ = pendota.isIdAllowed(_id_) ? _id_ : "";
+		var _classNames_ = pendota.filterClassNames((!!e ? e.classes : []) || []);
+		var _attrs_ = pendota.filterAttributes((!!e ? e.attributes : []) || []);
 		var _textContent_ = (!!e && !!e.textContent ? e.textContent.trim() : "") || "";
 		_textContent_ = _textContent_.replace(/(["])/g, "\\$1");
+		_textContent_ = pendota.isContainsAllowed(_textContent_) ? _textContent_ : '';
+
 		var _elemType_ = (!!e && !!e.nodeName ? e.nodeName.toLowerCase() : "") || ""; // stylistic choice to do lower case
 
 		var createItemRow = function(attr, rawVal, fmtVal) {

--- a/src/scripts/selectorRules.js
+++ b/src/scripts/selectorRules.js
@@ -14,7 +14,7 @@ window.pendota.filterClassNames = function (classNames) {
 };
 
 window.pendota.isIdAllowed = function (id) {
-    var idDenyList = [/^Ember.*/];
+    var idDenyList = [/^ember.*/i];
     return !idDenyList.some(function(idDenyListEl) {
         return id.match(idDenyListEl)
     });

--- a/src/scripts/selectorRules.js
+++ b/src/scripts/selectorRules.js
@@ -1,0 +1,131 @@
+if (typeof(window.pendota) === "undefined") {
+    // checks if the window pendota object already exists.
+    // all functions and global vars are stored under this object.
+	window.pendota = {};
+}
+
+window.pendota.filterClassNames = function (classNames) {
+    var classAllowList = [/^js-walkme-.*/, /^js-glue-.*/, /^js-walkme-.*/, /^z-.*/, 'btn', 'btn-primary'];
+    return classNames.filter(function(className) {
+        return classAllowList.some(function(classAllowListEl) {
+            return className.match(classAllowListEl)
+        })
+    });
+};
+
+window.pendota.isIdAllowed = function (id) {
+    var idDenyList = [/^Ember.*/];
+    return !idDenyList.some(function(idDenyListEl) {
+        return id.match(idDenyListEl)
+    });
+};
+
+window.pendota.filterAttributes = function (attributes) {
+    var attributeAllowList = [/^data-testid.*/, /^data-component.*/, 'href'];
+    return attributes.filter(function(attributeObj) {
+        return attributeAllowList.some(function(attributeAllowListEl) {
+            return attributeObj.attribute.match(attributeAllowListEl)
+        })
+    });
+};
+
+
+window.pendota.isContainsAllowed = function (text) {
+    return containsAllowList.some(listEl => listEl === text);
+}
+
+var containsAllowList = [
+    "Cancel",
+    "Save",
+    "Back",
+    "Finish Later",
+    "Continue",
+    "Go Back",
+    "Learn more",
+    "Next",
+    "Download",
+    "Finish",
+    "Learn More",
+    "View All",
+    "Confirm",
+    "Upload",
+    "View",
+    "contact support.",
+    "Back to Support",
+    "Bold",
+    "Terms",
+    "Privacy",
+    "Update",
+    "Articles list",
+    "Overview",
+    "Article 1",
+    "Article 2",
+    "Done",
+    "Close",
+    "Italic",
+    "Go to Dashboard",
+    "Learn More.",
+    "Learn more here.",
+    "Edit",
+    "Save Changes",
+    "Download Report",
+    "Edit article #",
+    "Individual Rates",
+    "Family Rates",
+    "more",
+    "Show",
+    "download our template",
+    "Get Started",
+    "Underline",
+    "Let's Get Started",
+    "Show modal",
+    "Contributions",
+    "View Progress",
+    "Click here",
+    "OK",
+    "Help Center article",
+    "Add your review",
+    "Back to Overview",
+    "See All",
+    "Help",
+    "Create Report",
+    "Add Object",
+    "Create",
+    "Unlink",
+    "Submit",
+    "Cancel Import",
+    "HR",
+    "PAYROLL",
+    "BENEFITS",
+    "TIME AND SCHEDULING",
+    "Legal",
+    "Delete",
+    "Create Survey",
+    "All",
+    "Search",
+    "Go back to dashboard",
+    "Create Post",
+    "Hide",
+    "<",
+    ">",
+    "Upload Spreadsheet",
+    "Map Job",
+    "Sign Up",
+    "How can I set goals for myself?",
+    "How do I schedule a One-on-One with a coworker?",
+    "All Reviewees",
+    "Show Less",
+    "All Reviews",
+    "Preview what",
+    "Export to PDF",
+    "Add Time Off Request",
+    "Unpprove",
+    "Create Policy",
+    "Add Timeframe",
+    "Create Statement",
+    "Clear All",
+    "Start",
+    "Resume",
+    "Open Modal",
+    "Action",
+]

--- a/src/ui/pendota.html
+++ b/src/ui/pendota.html
@@ -102,8 +102,6 @@
         <div class="_pendota_row-header_">
           <h5 class="_pendota_">Custom Attributes:</h5>
         </div>
-        <div id="_pendota-attr-selector_">
-        </div>
         <div class="_pendota_form-group_">
           <table width="100%" id="_pendota_attr-table_"></table>
         </div>

--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -64,6 +64,11 @@ chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
 						});
 
 						chrome.tabs.executeScript({
+							file: "./src/scripts/selectorRules.js",
+							allFrames: true,
+						});
+
+						chrome.tabs.executeScript({
 							file: "./src/scripts/insertBaseDefinitions.js",
 							allFrames: true,
 						});


### PR DESCRIPTION
Initial fork adds some changes to make the tool more useful for Zenefits:

- Filter out selectors that are not reliable within Zenefits:
  - ClassNames: z-*, js-walkme-*, js-glue-*, btn, btn-primary
  - Text contains - only if the text matches the allowList we sent to Pendo for text capture
  - id: filter out #ember
  - other attributes: only allow href, data-component, data-testid
- Other UI changes
  - Show all data attributes like we do for other section instead of showing one option with a dropdown. We don't have that many attributes that match so I think this works better
  - Hide sections when there are no results 